### PR TITLE
Add fortune command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@
 - If you want to play around with it, you will need to use your own bot token. You could then invite your own bot (with the token you got) to your own personal server and play around with it there for testing (this is all in the above guide) :)
 - For readability purposes, if you want to add an extensive function, please write it in a new python file placed in the `extensions` folder -- just like the `userinfo` command is.
 - You can install the required dependencies (listed in `requirements.txt`) using the command `pip install -r requirements.txt`.
+- The fortune module requires the fortune files to be installed and pointed to by the FORTUNE_DIRECTORY variable. Generally this means installing the `fortunes` package and setting `FORTUNE_DIRECTORY=/usr/share/games/fortunes`. You may optionally white- and black-list database files by settings FORTUNE_WHITELIST and/or FORTUNE_BLACKLIST to a space-separates list of database file names.

--- a/extensions/fortune.py
+++ b/extensions/fortune.py
@@ -1,0 +1,32 @@
+import os
+import re
+import random
+import hikari
+import lightbulb
+from fortune import get_random_fortune
+
+plugin = lightbulb.Plugin("Fortune")
+
+@plugin.command
+@lightbulb.command(
+    "fortune", "Print a fortune."
+)
+@lightbulb.implements(lightbulb.PrefixCommand, lightbulb.SlashCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    await ctx.respond(get_random_fortune(choose_file()))
+
+def choose_file() -> str:
+    basedir = os.environ["FORTUNE_DIRECTORY"]
+    files = [f for f in os.listdir(basedir) if
+            os.path.isfile(os.path.join(basedir, f))
+            and re.match("^[^.]+$", f)]
+    if "FORTUNE_WHITELIST" in os.environ:
+        whitelist = os.environ["FORTUNE_WHITELIST"].split()
+        files = filter(lambda f : f in whitelist, files)
+    if "FORTUNE_BLACKLIST" in os.environ:
+        blacklist = os.environ["FORTUNE_BLACKLIST"].split()
+        files = filter(lambda f : f not in blacklist, files)
+    return os.path.join(basedir, random.choice(list(files)))
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/extensions/fortune.py
+++ b/extensions/fortune.py
@@ -1,7 +1,6 @@
 import os
 import re
 import random
-import hikari
 import lightbulb
 from fortune import get_random_fortune
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ beautifulsoup4==4.11.1
 certifi==2021.10.8
 charset-normalizer==2.0.12
 colorlog==6.6.0
+fortune==1.1.0
 frozenlist==1.3.0
+grizzled-python==2.2.0
 hikari==2.0.0.dev108
 hikari-lightbulb==2.2.1
 idna==3.3


### PR DESCRIPTION
As per readme changes, this requires installing the `fortunes` package. The following environment configuration is also recommended:
```
FORTUNE_DIRECTORY=/usr/share/games/fortunes
FORTUNE_WHITELIST=computers linux
```