### PR TITLE
Message Stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 exampleScraper.py
 wiki.py
 /venv
+persist.sqlite

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ FORTUNE_DIRECTORY=/usr/share/games/fortunes # Location of where fortunes is inst
   - If you're on macOS you can install `fortunes` with `brew install fortune` and in `.env` set `FORTUNE_DIRECTORY=/usr/local/Cellar/fortune/9708/share/games/fortunes`
   - I don't have Windows so if you develop on Windows you'll have to find how to download the `fortunes` package yourself. If you can't find it it's fine, it just means the `+fortune` command won't work during testing (but everything else should).
   - You may optionally white-list and black-list database files by setting `FORTUNE_WHITELIST` and/or `FORTUNE_BLACKLIST` to a space-separated list of database file names.
+- The bot can grant a role to members when they first send a text message. Conventionally, this role is called `#NotALurker`. To enable this feature the `NOTALURKER_ROLE` parameter in `.env` must be set to the role ID to grant. The bot's role must be higher than this role to have permission to grant it.
 - The bot is deployed on a cloud server (droplet on Digital Ocean) which runs Ubuntu 20.04. 
 
 ## Current Functionality

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ FORTUNE_DIRECTORY=/usr/share/games/fortunes # Location of where fortunes is inst
 - `+userinfo` command: Returns an embed containing useful information of a specified member of the server. If no member is specified, it returns that of the user who issued the command.
 - `/say`: Writes a custom text message encapsulated in something rather interesting... 
 - For `/translate` there's 2 options. The first is the text, and the second is the language you want to translate into (you write the language code, e.g. `fr` for french). If you don't specify the language code, then it assumes you want to translate the text you write into English.
+- `/userstats`: By default, show a bar chart of the top 10 users' message counts. If the optional argument, a user, is given then show the message and emoji counts for that user.
 - All commands have a 10-second cooldown period (per user), and can also be called in slash command form.
 
 ## Further Ideas // Ways to Contribute

--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, re, random
+import os
 import dotenv, aiohttp
 import hikari, lightbulb
 
@@ -18,14 +18,6 @@ bot = lightbulb.BotApp(
 @bot.listen(hikari.StartedEvent)
 async def botStartup(event):
     print("Bot has started up!")
-
-# Simple ping-pong command example.
-@bot.command
-@lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
-@lightbulb.command("ping", description="The bot's ping")
-@lightbulb.implements(lightbulb.PrefixCommand)
-async def ping(ctx: lightbulb.Context) -> None:
-    await ctx.respond(f"Pong! Latency: {bot.heartbeat_latency*1000:.2f}ms")
 
 
 @bot.listen(lightbulb.CommandErrorEvent)

--- a/bot.py
+++ b/bot.py
@@ -28,40 +28,6 @@ async def ping(ctx: lightbulb.Context) -> None:
     await ctx.respond(f"Pong! Latency: {bot.heartbeat_latency*1000:.2f}ms")
 
 
-"""
-Bot adds #notalurker role for those who comment.
-"""
-@bot.listen(hikari.GuildMessageCreateEvent)
-async def give_role(event):
-
-    if event.is_bot or not event.content:
-        return
-    
-    channelSentIn = event.channel_id
-    if channelSentIn != 938847222601240656 and channelSentIn != 938894077519356004 and event.get_member().id != 940684135687659581:
-        messageContent = event.content
-        messageContent = re.sub(r'<.+?>', "", messageContent)
-        print(f"Sender: {event.author} | Content: {messageContent}")
-
-        if any(c.isalpha() for c in messageContent):
-            print("Message contains valid symbols.")
-            currentRoles = (await event.get_member().fetch_roles())[1:]
-            hasRole = False
-            for role in currentRoles:
-                # print(f"{role}: {type(role)}")
-                if role.id == 847009026817654805 or role.id == 938871141110517761:
-                    print("Already has role.\n")
-                    hasRole = True
-            if hasRole is False: # User doesn't have the role yet, and we need to give it to them.
-                print("Giving role now.\n")
-                if event.guild_id == 813213508036067348: # CS
-                    print("CS server.")
-                    await event.get_member().add_role(847009026817654805) 
-                elif event.guild_id == 798180001101905940: # Personal
-                    print("Personal server.")
-                    await event.get_member().add_role(938871141110517761)
-
-
 @bot.listen(lightbulb.CommandErrorEvent)
 async def on_error(event: lightbulb.CommandErrorEvent) -> None:
     if isinstance(event.exception, lightbulb.CommandInvocationError):

--- a/bot.py
+++ b/bot.py
@@ -61,16 +61,6 @@ async def give_role(event):
                     print("Personal server.")
                     await event.get_member().add_role(938871141110517761)
 
-"""
-The below command demonstrates input parameters.
-"""
-@bot.command
-@lightbulb.option('num1', 'First number', type=int) # Options must be under the @bot.command and above the @lightbulb.command
-@lightbulb.option('num2', 'Second number', type=int)
-@lightbulb.command('numberadder', 'Adds 2 numbers together')
-@lightbulb.implements(lightbulb.PrefixCommand, lightbulb.SlashCommand)
-async def add(ctx):
-    await ctx.respond(ctx.options.num1+ctx.options.num2) # Because we want the bot to respond back with some information.
 
 @bot.listen(lightbulb.CommandErrorEvent)
 async def on_error(event: lightbulb.CommandErrorEvent) -> None:

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
 import os, re, random, hashlib, datetime
-import dotenv, aiohttp, requests
+import dotenv, aiohttp
 import hikari, lightbulb
-from bs4 import BeautifulSoup
 
 dotenv.load_dotenv()
 
@@ -15,21 +14,6 @@ bot = lightbulb.BotApp(
         default_enabled_guilds=tuple(int(v) for v in os.environ["DEFAULT_GUILDS"].split(','))
         )
 
-misconceptionsURL = "https://en.wikipedia.org/wiki/List_of_common_misconceptions"
-page = requests.get(misconceptionsURL) 
-soup = BeautifulSoup(page.content, "html.parser") 
-results = soup.find(class_="mw-parser-output")
-
-lists = results.find_all("ul") # Returns an iterable of all lists on the page.
-randomFacts = []
-tips = []
-
-for i in range(13, 79):
-    for line in lists[i]:
-        if line != '\n':
-            line = re.sub("[\[].*?[\]]", "", line.text)
-            # print(f"- {line}\n")
-            randomFacts.append(line)
 
 eight_ball_responses = [ "It is certain.", "It is decidedly so.", "Without a doubt.", "Yes, definitely.",
                "You may rely on it.", "As I see it, yes.", "Most likely.", "Outlook good.",
@@ -48,17 +32,6 @@ async def botStartup(event):
 @lightbulb.implements(lightbulb.PrefixCommand)
 async def ping(ctx: lightbulb.Context) -> None:
     await ctx.respond(f"Pong! Latency: {bot.heartbeat_latency*1000:.2f}ms")
-
-# Random fact.
-@bot.command
-@lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
-@lightbulb.command("fact", description="Gives a random fact!")
-@lightbulb.implements(lightbulb.PrefixCommand)
-async def give_fact(ctx: lightbulb.Context) -> None:
-    randomNumber = random.randint(0,322)
-    target = ctx.get_guild().get_member(ctx.user)
-    print(f"---> Hi @{target.display_name}! Did you know this? :disguised_face:\n{randomFacts[randomNumber]}")
-    await ctx.respond(f"---> {ctx.author.mention}, did you know this?  :cat:\n\n{randomFacts[randomNumber]}", user_mentions=[target, True])
 
 def choose_eightball_response(message):
     # Add current date down to hour precision to vary the response periodically

--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, re, random, hashlib, datetime
+import os, re, random
 import dotenv, aiohttp
 import hikari, lightbulb
 
@@ -15,12 +15,6 @@ bot = lightbulb.BotApp(
         )
 
 
-eight_ball_responses = [ "It is certain.", "It is decidedly so.", "Without a doubt.", "Yes, definitely.",
-               "You may rely on it.", "As I see it, yes.", "Most likely.", "Outlook good.",
-               "Yes.", "Signs point to yes.", "Reply hazy, try again.", "Ask again later.",
-               "Better not tell you now.", "Cannot predict now.", "Concentrate and ask again.",
-               "Don't count on it.", "My reply is no.", "My sources say no.", "Outlook not so good.", "Very Doubtful."]
-
 @bot.listen(hikari.StartedEvent)
 async def botStartup(event):
     print("Bot has started up!")
@@ -33,37 +27,6 @@ async def botStartup(event):
 async def ping(ctx: lightbulb.Context) -> None:
     await ctx.respond(f"Pong! Latency: {bot.heartbeat_latency*1000:.2f}ms")
 
-def choose_eightball_response(message):
-    # Add current date down to hour precision to vary the response periodically
-    hash_input = message + datetime.datetime.now().strftime('%Y%m%d%H')
-    index = hashlib.md5(hash_input.encode()).digest()[0] % len(eight_ball_responses)
-    return eight_ball_responses[index]
-    
-def findWholeWord(word, text):
-    return re.compile(r'\b({0})\b'.format(word), flags=re.IGNORECASE).search(text)
-
-@bot.listen(hikari.GuildMessageCreateEvent)
-async def tags_bot(event):
-    if event.is_bot or not event.content:
-        return
-    mentioned_ids = event.message.mentions.user_ids
-    if bot.application.id not in mentioned_ids:
-        return
-    messageContent = event.content
-    regexp = re.compile('(\S|\s)\?(\s|$)')
-    if regexp.search(messageContent):
-        print("Giving 8-ball response.")
-        await event.message.respond(choose_eightball_response(messageContent))
-    elif findWholeWord('broken', messageContent):
-        await event.message.respond(f"No {event.author.mention}, you're broken :disguised_face:")
-    elif findWholeWord('thanks', messageContent) or findWholeWord('thank', messageContent):
-        await event.message.respond(f"You're welcome :heart:")
-    elif findWholeWord('work', messageContent):
-        await event.message.respond(f"{event.author.mention} I do work.")
-    elif findWholeWord('hey', messageContent) or findWholeWord('hi', messageContent) or findWholeWord('hello', messageContent):
-        await event.message.respond(f"Hey {event.author.mention}, I am a cat. With robot intestines. If you're bored, you should ask me a question, or check out my `+userinfo`, `+ping`, `+fortune` and `+fact` commands :cat:")
-    else:
-        await event.message.respond(f"{event.author.mention}, did you forget a question mark? <:mmhmmm:872809423939174440>")
 
 """
 Bot adds #notalurker role for those who comment.

--- a/db.py
+++ b/db.py
@@ -1,0 +1,26 @@
+import sqlite3
+
+def cursor():
+    return conn.cursor()
+
+def commit():
+    conn.commit()
+
+def insert(table, data):
+    c = cursor()
+    keys = [*data]
+    template_list = ','.join(['?'] * len(data))
+    query = f"INSERT INTO {table} ({','.join(keys)}) VALUES ({template_list})"
+    c.execute(query, tuple(data[k] for k in keys))
+    commit()
+
+def start():
+    c = cursor()
+    c.execute("CREATE TABLE IF NOT EXISTS emoji_counts (user TEXT, emoji TEXT, count INTEGER)");
+    c.execute("CREATE UNIQUE INDEX IF NOT EXISTS emoji_counts_idx ON emoji_counts (user, emoji)");
+    c.execute("CREATE TABLE IF NOT EXISTS message_counts (user TEXT, count INTEGER)");
+    c.execute("CREATE UNIQUE INDEX IF NOT EXISTS message_counts_idx ON message_counts (user)");
+
+conn = sqlite3.connect('persist.sqlite')
+start()
+

--- a/db.py
+++ b/db.py
@@ -6,14 +6,6 @@ def cursor():
 def commit():
     conn.commit()
 
-def insert(table, data):
-    c = cursor()
-    keys = [*data]
-    template_list = ','.join(['?'] * len(data))
-    query = f"INSERT INTO {table} ({','.join(keys)}) VALUES ({template_list})"
-    c.execute(query, tuple(data[k] for k in keys))
-    commit()
-
 def start():
     c = cursor()
     c.execute("CREATE TABLE IF NOT EXISTS emoji_counts (user TEXT, emoji TEXT, count INTEGER)");

--- a/extensions/adder.py
+++ b/extensions/adder.py
@@ -1,0 +1,14 @@
+import lightbulb
+
+plugin = lightbulb.Plugin("Adder")
+
+@plugin.command
+@lightbulb.option('num2', 'Second number', type=int)
+@lightbulb.option('num1', 'First number', type=int)
+@lightbulb.command('numberadder', 'Adds 2 numbers together')
+@lightbulb.implements(lightbulb.PrefixCommand, lightbulb.SlashCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    await ctx.respond(ctx.options.num1 + ctx.options.num2)
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/extensions/fact.py
+++ b/extensions/fact.py
@@ -15,7 +15,7 @@ def init():
     for i in range(13, 79):
         for line in lists[i]:
             if line != '\n':
-                line = re.sub(r"\[[^\]]+]", "", line.text)
+                line = re.sub(r"\[.*?\]", "", line.text)
                 randomFacts.append(line)
 
 @plugin.command

--- a/extensions/fact.py
+++ b/extensions/fact.py
@@ -1,0 +1,33 @@
+import random, re
+import requests
+from bs4 import BeautifulSoup
+import lightbulb
+
+plugin = lightbulb.Plugin("Fact")
+randomFacts = []
+
+def init():
+    misconceptionsURL = "https://en.wikipedia.org/wiki/List_of_common_misconceptions"
+    page = requests.get(misconceptionsURL) 
+    soup = BeautifulSoup(page.content, "html.parser") 
+    results = soup.find(class_="mw-parser-output")
+    lists = results.find_all("ul") # Returns an iterable of all lists on the page.
+    for i in range(13, 79):
+        for line in lists[i]:
+            if line != '\n':
+                line = re.sub(r"\[[^\]]+]", "", line.text)
+                print(line)
+                randomFacts.append(line)
+
+@plugin.command
+@lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
+@lightbulb.command("fact", description="Gives a random fact!")
+@lightbulb.implements(lightbulb.PrefixCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    target = ctx.get_guild().get_member(ctx.user)
+    fact = random.choice(randomFacts)
+    await ctx.respond(f"---> {ctx.author.mention}, did you know this?  :cat:\n\n{fact}", user_mentions=[target, True])
+
+def load(bot: lightbulb.BotApp) -> None:
+    init()
+    bot.add_plugin(plugin)

--- a/extensions/fact.py
+++ b/extensions/fact.py
@@ -23,9 +23,8 @@ def init():
 @lightbulb.command("fact", description="Gives a random fact!")
 @lightbulb.implements(lightbulb.PrefixCommand)
 async def main(ctx: lightbulb.Context) -> None:
-    target = ctx.get_guild().get_member(ctx.user)
     fact = random.choice(randomFacts)
-    await ctx.respond(f"---> {ctx.author.mention}, did you know this?  :cat:\n\n{fact}", user_mentions=[target, True])
+    await ctx.respond(f"---> {ctx.author.mention}, did you know this?  :cat:\n\n{fact}", user_mentions=True)
 
 def load(bot: lightbulb.BotApp) -> None:
     init()

--- a/extensions/fact.py
+++ b/extensions/fact.py
@@ -16,7 +16,6 @@ def init():
         for line in lists[i]:
             if line != '\n':
                 line = re.sub(r"\[[^\]]+]", "", line.text)
-                print(line)
                 randomFacts.append(line)
 
 @plugin.command

--- a/extensions/notalurker.py
+++ b/extensions/notalurker.py
@@ -1,0 +1,30 @@
+import os, re
+import hikari, lightbulb
+
+plugin = lightbulb.Plugin("NotALurker")
+
+"""
+Bot adds #notalurker role for those who comment.
+"""
+@plugin.listener(hikari.GuildMessageCreateEvent)
+async def main(event):
+    if event.is_bot or not event.content or "NOTALURKER_ROLE" not in os.environ:
+        return
+    channelSentIn = event.channel_id
+    messageContent = event.content
+    messageContent = re.sub(r'<.+?>', "", messageContent)
+    print(f"Sender: {event.author} | Content: {messageContent}")
+    if not any(c.isalpha() for c in messageContent):
+        return
+    print("Message contains valid symbols.")
+    currentRoles = (await event.get_member().fetch_roles())[1:]
+    for role in currentRoles:
+        if role.id == int(os.environ["NOTALURKER_ROLE"]):
+            print("Already has role.\n")
+            return
+    print("Giving role now.\n")
+    await event.get_member().add_role(int(os.environ["NOTALURKER_ROLE"])) 
+
+def load(bot: lightbulb.BotApp):
+    bot.add_plugin(plugin)
+

--- a/extensions/ping.py
+++ b/extensions/ping.py
@@ -1,0 +1,13 @@
+import lightbulb
+
+plugin = lightbulb.Plugin("Ping")
+
+@plugin.command
+@lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
+@lightbulb.command("ping", description="The bot's ping")
+@lightbulb.implements(lightbulb.PrefixCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    await ctx.respond(f"Pong! Latency: {plugin.bot.heartbeat_latency*1000:.2f}ms")
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/extensions/snark.py
+++ b/extensions/snark.py
@@ -27,18 +27,20 @@ async def main(event) -> None:
         return
     messageContent = event.content
     regexp = re.compile(r'(\S|\s)\?(\s|$)')
+    response = None
     if regexp.search(messageContent):
-        await event.message.respond(choose_eightball_response(messageContent))
+        response = choose_eightball_response(messageContent)
     elif find_whole_word('broken', messageContent):
-        await event.message.respond(f"No {event.author.mention}, you're broken :disguised_face:")
+        response = f"No {event.author.mention}, you're broken :disguised_face:"
     elif find_whole_word('thanks', messageContent) or find_whole_word('thank', messageContent):
-        await event.message.respond(f"You're welcome :heart:")
+        response = f"You're welcome :heart:"
     elif find_whole_word('work', messageContent):
-        await event.message.respond(f"{event.author.mention} I do work.")
+        response = f"{event.author.mention} I do work."
     elif find_whole_word('hey', messageContent) or find_whole_word('hi', messageContent) or find_whole_word('hello', messageContent):
-        await event.message.respond(f"Hey {event.author.mention}, I am a cat. With robot intestines. If you're bored, you should ask me a question, or check out my `+userinfo`, `+ping`, `+fortune` and `+fact` commands :cat:")
+        response = f"Hey {event.author.mention}, I am a cat. With robot intestines. If you're bored, you should ask me a question, or check out my `+userinfo`, `+ping`, `+fortune` and `+fact` commands :cat:"
     else:
-        await event.message.respond(f"{event.author.mention}, did you forget a question mark? <:mmhmmm:872809423939174440>")
+        response = f"{event.author.mention}, did you forget a question mark? <:mmhmmm:872809423939174440>"
+    await event.message.respond(response, user_mentions=True)
 
 def load(bot: lightbulb.BotApp) -> None:
     bot.add_plugin(plugin)

--- a/extensions/snark.py
+++ b/extensions/snark.py
@@ -1,0 +1,44 @@
+import re, datetime, hashlib
+import hikari, lightbulb
+
+plugin = lightbulb.Plugin("Snark")
+
+eight_ball_responses = [ "It is certain.", "It is decidedly so.", "Without a doubt.", "Yes, definitely.",
+               "You may rely on it.", "As I see it, yes.", "Most likely.", "Outlook good.",
+               "Yes.", "Signs point to yes.", "Reply hazy, try again.", "Ask again later.",
+               "Better not tell you now.", "Cannot predict now.", "Concentrate and ask again.",
+               "Don't count on it.", "My reply is no.", "My sources say no.", "Outlook not so good.", "Very Doubtful."]
+
+def choose_eightball_response(message):
+    # Add current date down to hour precision to vary the response periodically
+    hash_input = message + datetime.datetime.now().strftime('%Y%m%d%H')
+    index = hashlib.md5(hash_input.encode()).digest()[0] % len(eight_ball_responses)
+    return eight_ball_responses[index]
+
+def find_whole_word(word, text):
+    return re.compile(r'\b({0})\b'.format(word), flags=re.IGNORECASE).search(text)
+
+@plugin.listener(hikari.GuildMessageCreateEvent)
+async def main(event) -> None:
+    if event.is_bot or not event.content:
+        return
+    mentioned_ids = event.message.mentions.user_ids
+    if plugin.bot.application.id not in mentioned_ids:
+        return
+    messageContent = event.content
+    regexp = re.compile(r'(\S|\s)\?(\s|$)')
+    if regexp.search(messageContent):
+        await event.message.respond(choose_eightball_response(messageContent))
+    elif find_whole_word('broken', messageContent):
+        await event.message.respond(f"No {event.author.mention}, you're broken :disguised_face:")
+    elif find_whole_word('thanks', messageContent) or find_whole_word('thank', messageContent):
+        await event.message.respond(f"You're welcome :heart:")
+    elif find_whole_word('work', messageContent):
+        await event.message.respond(f"{event.author.mention} I do work.")
+    elif find_whole_word('hey', messageContent) or find_whole_word('hi', messageContent) or find_whole_word('hello', messageContent):
+        await event.message.respond(f"Hey {event.author.mention}, I am a cat. With robot intestines. If you're bored, you should ask me a question, or check out my `+userinfo`, `+ping`, `+fortune` and `+fact` commands :cat:")
+    else:
+        await event.message.respond(f"{event.author.mention}, did you forget a question mark? <:mmhmmm:872809423939174440>")
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/extensions/stats.py
+++ b/extensions/stats.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from itertools import chain
 from emoji import emoji_list
 import hikari, lightbulb
@@ -30,7 +31,7 @@ async def analyse_reaction(event) -> None:
         add_emoji_count(cursor, [(event.user_id, event.emoji_name)])
     else:
         # Discord specific
-        add_emoji_count(cursor, [(event.user_id, str(event.emoji_id))])
+        add_emoji_count(cursor, [(event.user_id, f'<:{event.emoji_name}:{event.emoji_id}>')])
     db.commit()
 
 @plugin.listener(hikari.GuildMessageCreateEvent)
@@ -39,12 +40,97 @@ async def analyse_message(event) -> None:
         return
     cursor = db.cursor()
     add_message_count(cursor, str(event.author_id))
-    custom_emoji = re.findall(r'<:.+?:(\d+)>', event.content)
+    custom_emoji = re.findall(r'<:.+?:\d+>', event.content)
     unicode_emoji = emoji_list(event.content)
     emoji = custom_emoji + [x['emoji'] for x in unicode_emoji]
     if len(emoji):
         add_emoji_count(cursor, [(str(event.author_id), e) for e in emoji])
     db.commit()
 
+async def show_user_stats(ctx: lightbulb.Context, user) -> None:
+    user_id = user.id
+    cursor = db.cursor()
+    cursor.execute("""
+        SELECT emoji, count FROM emoji_counts
+        WHERE user = ?
+        ORDER BY count DESC
+        LIMIT 10""",
+        (user_id,))
+    emoji = cursor.fetchall()
+    cursor.execute("""
+        SELECT count FROM message_counts
+        WHERE user = ?""",
+        (user_id,))
+    message_count = cursor.fetchone()
+    embed = (
+        hikari.Embed(
+            title=f"User Stats = {user.display_name}",
+            description=f"ID: `{user.id}`",
+            colour=0x3B9DFF,
+            timestamp=datetime.now().astimezone()
+        )
+        .set_thumbnail(user.avatar_url or user.default_avatar_url)
+        .add_field(
+            "Messages sent",
+            message_count[0] if message_count else 'None',
+            inline=False
+        )
+        .add_field(
+            "Top 10 emoji",
+            ', '.join([f'{name} ({count})' for (name, count) in emoji]) if len(emoji) else 'None',
+            inline=False
+        )
+    )
+    await ctx.respond(embed)
+
+async def show_message_stats(ctx: lightbulb.Context) -> None:
+    MAX_BAR_LENGTH = 30
+    SLICES_PER_CHAR = 8
+    BLOCK_CODEPOINT = 0x2588
+    guild = ctx.get_guild()
+    cursor = db.cursor()
+    cursor.execute("""
+        SELECT user, count FROM message_counts
+        ORDER BY count DESC
+        LIMIT 10""")
+    data = cursor.fetchall()
+    if len(data) == 0:
+        await ctx.respond("No one has said anything. How bizarre.")
+        return
+    max_messages = data[0][1]
+    max_messages_width = len(str(max_messages))
+    max_name_length = 0
+    users_counts = []
+    for (user_id, message_count) in data:
+        user = guild.get_member(user_id)
+        if not user:
+            display_name = str(user_id)
+        else:
+            display_name = user.display_name
+        max_name_length = max(max_name_length, len(display_name))
+        users_counts.append((display_name, message_count))
+    message = ['```']
+    for (name, count) in users_counts:
+        line = f'{name.rjust(max_name_length)} : {str(count).rjust(max_messages_width)} '
+        slices = int((MAX_BAR_LENGTH * SLICES_PER_CHAR) * (count / max_messages))
+        bar = chr(BLOCK_CODEPOINT) * (slices // SLICES_PER_CHAR)
+        if slices % SLICES_PER_CHAR > 0:
+            bar += chr(BLOCK_CODEPOINT + SLICES_PER_CHAR - (slices % SLICES_PER_CHAR))
+        message.append(line + bar)
+    message.append('```')
+    await ctx.respond('\n'.join(message))
+
+@plugin.command
+@lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
+@lightbulb.option("target", "The member to show stats about.", hikari.User, required=False)
+@lightbulb.command("userstats", "Get message stats")
+@lightbulb.implements(lightbulb.PrefixCommand,lightbulb.SlashCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    if ctx.options.target:
+        user = ctx.get_guild().get_member(ctx.options.target)
+        await show_user_stats(ctx, user)
+    else:
+        await show_message_stats(ctx)
+    
 def load(bot: lightbulb.BotApp) -> None:
     bot.add_plugin(plugin)

--- a/extensions/stats.py
+++ b/extensions/stats.py
@@ -1,0 +1,50 @@
+import re
+from itertools import chain
+from emoji import emoji_list
+import hikari, lightbulb
+import db
+
+plugin = lightbulb.Plugin("Stats")
+
+def add_emoji_count(cursor, usages):
+    cursor.execute(f"""
+        INSERT INTO emoji_counts (user, emoji, count)
+        VALUES {','.join(['(?, ?, 1)'] * len(usages))} 
+        ON CONFLICT (user, emoji) DO UPDATE
+        SET count = emoji_counts.count + 1""",
+        tuple(chain.from_iterable(usages)))
+
+def add_message_count(cursor, user_id):
+    cursor.execute("""
+        INSERT INTO message_counts (user, count)
+        VALUES (?, 1)
+        ON CONFLICT (user) DO UPDATE
+        SET count = message_counts.count + 1""",
+        (user_id,))
+
+@plugin.listener(hikari.GuildReactionAddEvent)
+async def analyse_reaction(event) -> None:
+    cursor = db.cursor()
+    if event.emoji_id is None:
+        # Standard unicode emoji character
+        add_emoji_count(cursor, [(event.user_id, event.emoji_name)])
+    else:
+        # Discord specific
+        add_emoji_count(cursor, [(event.user_id, str(event.emoji_id))])
+    db.commit()
+
+@plugin.listener(hikari.GuildMessageCreateEvent)
+async def analyse_message(event) -> None:
+    if event.is_bot or not event.content:
+        return
+    cursor = db.cursor()
+    add_message_count(cursor, str(event.author_id))
+    custom_emoji = re.findall(r'<:.+?:(\d+)>', event.content)
+    unicode_emoji = emoji_list(event.content)
+    emoji = custom_emoji + [x['emoji'] for x in unicode_emoji]
+    if len(emoji):
+        add_emoji_count(cursor, [(str(event.author_id), e) for e in emoji])
+    db.commit()
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 colorlog==6.6.0
 cowsay==4.0
+emoji==1.7.0
 fortune==1.1.0
 frozenlist==1.3.0
 grizzled-python==2.2.0


### PR DESCRIPTION
- The headline feature: Adds a stats plugin that counts the number of messages per user, as well as emoji usage in messages & reactions per user. This is stored in an sqlite database.
- The /userstats command shows a top 10 users by message counts, or shows the message and emoji counts for a user if given.
- Moves all the command implementations to their own plugin files for neatness. Also fixes @mentions so they display properly on mobiles.
- The NotALurker role granting feature now depends on an environment variable NOTALURKER_ROLE, see readme.

Lightly tested, as always.
