### PR TITLE
Sets to know ranks beyond 10

### DIFF
--- a/extensions/messageboard.py
+++ b/extensions/messageboard.py
@@ -41,7 +41,7 @@ async def show_message_stats(ctx: lightbulb.Context, plot_type, set_num) -> None
         SLICES_PER_CHAR = 8
         BLOCK_CODEPOINT = 0x2588
 
-        message = ['**Messages Tally from {} to {}** :cat:```'.format(set_num*10, 10)]
+        message = ['**Messages Tally from {} to {}** :cat:```'.format(set_num*10 + 1, set_num*10 + 10)]
         for (name, count) in users_counts:
             line = f'{name.rjust(max_name_length)} : {str(count).rjust(max_messages_width)} '
             slices = int((MAX_BAR_LENGTH * SLICES_PER_CHAR) * (count / max_messages))
@@ -72,7 +72,7 @@ async def show_message_stats(ctx: lightbulb.Context, plot_type, set_num) -> None
         ax.bar_label(bars)
         # ax.set_xlabel('Members', labelpad=10, color='#333333', fontsize='12')
         ax.set_ylabel('Total Messages', labelpad=15, color='#333333', fontsize='12')
-        ax.set_title('Messages Tally! from {} to {}'.format(set_num*10, 10), pad=15, color='#333333', weight='bold', fontsize='15')
+        ax.set_title('Messages Tally! from {} to {}'.format(set_num*10 + 1, set_num*10 + 10), pad=15, color='#333333', weight='bold', fontsize='15')
         ax.set_facecolor('#f5f5f5')
         plt.yticks(fontsize=8)
         plt.xticks(fontsize=(95/max_name_length))
@@ -103,7 +103,7 @@ async def show_message_stats(ctx: lightbulb.Context, plot_type, set_num) -> None
         ax.bar_label(bars, color='#fff')
         # ax.set_xlabel('Members', labelpad=10, color='#333333', fontsize='12')
         ax.set_ylabel(r'Total Messages', labelpad=15, color='#e6e7e7', fontsize='12')
-        ax.set_title('Messages Tally! from {} to {}'.format(set_num*10, 10), pad=15, color='#e6e7e7', weight='bold', fontsize='15')
+        ax.set_title('Messages Tally! from {} to {}'.format(set_num*10 + 1, set_num*10 + 10), pad=15, color='#e6e7e7', weight='bold', fontsize='15')
 
         # Set Background Colour to default Discord Background
         ax.set_facecolor('#36393f')

--- a/extensions/pickupline.py
+++ b/extensions/pickupline.py
@@ -1,0 +1,24 @@
+import lightbulb
+import requests
+
+plugin = lightbulb.Plugin("PickUpLine")
+
+@plugin.command
+@lightbulb.command(
+    "pickupline", "Prints a Pick up Line."
+)
+@lightbulb.implements(lightbulb.SlashCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    await ctx.respond(pickupline())
+
+def pickupline() -> str:
+    return get_random_pickup_line()
+
+
+def get_random_pickup_line() -> str:
+    response = requests.get("http://getpickuplines.herokuapp.com/lines/random")
+    return response.json()["line"]
+
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/extensions/snark.py
+++ b/extensions/snark.py
@@ -38,6 +38,8 @@ async def main(event) -> None:
         response = f"{event.author.mention} I do work."
     elif find_whole_word('hey', messageContent) or find_whole_word('hi', messageContent) or find_whole_word('hello', messageContent):
         response = f"Hey {event.author.mention}, I am a cat. With robot intestines. If you're bored, you should ask me a question, or check out my `+userinfo`, `+ping`, `+fortune` and `+fact` commands :cat:"
+    elif event.message.referenced_message and event.message.referenced_message.author.id == plugin.bot.application.id:
+        return
     else:
         response = f"{event.author.mention}, did you forget a question mark? <:mmhmmm:872809423939174440>"
     await event.message.respond(response, user_mentions=True)


### PR DESCRIPTION
- Added sets to know ranks beyond 10. Use set=0,1,2.. etc to view 1-10, 11-20, 21-30....
- Changed the colour of the 10th bar for better legibility
- Super Lightly Tested (I didn't have a server with 10+ members in which I could test it)
- Fixed #24 
![Screenshot_2022-06-29-21-13-23-40_572064f74bd5f9fa804b05334aa4f912.jpg](https://user-images.githubusercontent.com/28804645/176480179-a2ae7433-35b1-4f1c-b034-7bc3a96d71af.jpg)

- Added Pickup Lines Extension