### PR TITLE
deletion of duplicate messages / originality enforcement mechanism

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,4 +1,5 @@
 import sqlite3
+import hashlib
 
 def cursor():
     return conn.cursor()
@@ -12,7 +13,13 @@ def start():
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS emoji_counts_idx ON emoji_counts (user, emoji)");
     c.execute("CREATE TABLE IF NOT EXISTS message_counts (user TEXT, count INTEGER)");
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS message_counts_idx ON message_counts (user)");
+    c.execute("CREATE TABLE IF NOT EXISTS message_hashes (user TEXT, message_id TEXT, message_hash TEXT)");
+    c.execute("CREATE UNIQUE INDEX IF NOT EXISTS message_hashes_idx ON message_hashes (message_hash)");
+
+def md5sum(m):
+    return hashlib.md5(m.encode('utf-8')).hexdigest()
 
 conn = sqlite3.connect('persist.sqlite')
+conn.create_function("md5", 1, md5sum)
 start()
 

--- a/extensions/duplicate_message_policing.py
+++ b/extensions/duplicate_message_policing.py
@@ -1,0 +1,75 @@
+"""
+Checks messages such that they are not duplicates of messages sent previously in the discord channel(s).
+This is designed to increase the effort required by users. For example, the string 'lol' can only be used
+once, and subsequent uses must get more creative (e.g. 'l0l', 'lolz', and so on).
+Eventually, some time in the future, all possible strings will have been said, and the database will need to be reset.
+
+Inspired by: https://blog.xkcd.com/2008/01/14/robot9000-and-xkcd-signal-attacking-noise-in-chat/
+"""
+import os, re
+import hikari, lightbulb
+import db
+import hashlib
+import sqlite3
+import re
+
+
+plugin = lightbulb.Plugin("duplicate_message_policing")
+
+
+@plugin.listener(hikari.GuildMessageCreateEvent)
+async def delete_duplicate(event: hikari.GuildMessageCreateEvent) -> None:
+    """
+    Deletes duplicate messages (excepting some). A duplicate message is simply a matching string
+    that has been seen before in the server (and not deleted).
+    """
+
+    nodelete_flag = "!"
+    # random rules. Probably worth thinking about this some more, if this bot function doesn't get deleted.
+    if (
+        (
+            event.channel_id != 813266892818219038 and os.environ.get("DEBUG") is None
+        )  # channel id is for #offtopic
+        or event.content is None
+        or event.is_webhook
+        or event.content.startswith(nodelete_flag)
+        or event.is_bot
+        or not event.content
+        or "http" in event.content  # allow links
+        or "@" in event.content  # allow mentions
+        or len(event.content) <= 4  # allow short messages
+    ):
+        # force the bot to not interact with this message at all e.g. in case of bug or in some other cases
+        return
+
+    cursor = db.cursor()
+
+    # todo: insert message exceptions such as emoji which are allowed to be duplicated
+    try:
+        cursor.execute(
+            "insert into message_hashes values(?, ?, md5(?))",
+            (event.author_id, event.message_id, event.content),
+        )
+        db.commit()
+    except sqlite3.IntegrityError as e:
+        await event.message.delete()
+        await event.message.respond(
+            f"Your message: ```{event.message.content}``` was deleted as it is not unique. Either change your message a bit or add ! to the start of it."
+        )
+
+
+@plugin.listener(hikari.GuildMessageDeleteEvent)
+async def delete_hash(event: hikari.GuildMessageDeleteEvent) -> None:
+    """
+    Deletes a message record such that another user (or the same user) can send this message again.
+    """
+    cursor = db.cursor()
+
+    cursor.execute(
+        "delete from message_hashes where message_id = ?", (event.message_id,)
+    )
+    db.commit()
+
+
+def load(bot: lightbulb.BotApp):
+    bot.add_plugin(plugin)

--- a/extensions/duplicate_message_policing.py
+++ b/extensions/duplicate_message_policing.py
@@ -9,7 +9,6 @@ Inspired by: https://blog.xkcd.com/2008/01/14/robot9000-and-xkcd-signal-attackin
 import os, re
 import hikari, lightbulb
 import db
-import hashlib
 import sqlite3
 import re
 
@@ -28,16 +27,15 @@ async def delete_duplicate(event: hikari.GuildMessageCreateEvent) -> None:
     # random rules. Probably worth thinking about this some more, if this bot function doesn't get deleted.
     if (
         (
-            event.channel_id != 813266892818219038 and os.environ.get("DEBUG") is None
+            event.channel_id != os.environ.get("ORIGINALITY_CHANNEL_ID") and os.environ.get("DEBUG") is None
         )  # channel id is for #offtopic
-        or event.content is None
         or event.is_webhook
         or event.content.startswith(nodelete_flag)
         or event.is_bot
         or not event.content
         or "http" in event.content  # allow links
         or "@" in event.content  # allow mentions
-        or len(event.content) <= 4  # allow short messages
+        or len(event.content) <= 2  # allow short messages
     ):
         # force the bot to not interact with this message at all e.g. in case of bug or in some other cases
         return


### PR DESCRIPTION
Creativity must be enforced by an unrelenting, unyielding, uncompromising bot. Duplicate messages in #offtopic which do not match an excepted pattern (such as containing http or being <= 4 characters long) will be deleted.

I didn't know how to make the deletion message only visible to the single user. I also don't know if offtopic is a good channel to trial this. Finally, I don't know if this is good/fun/interesting, but it might at least provide a bit of amusement and healthy or unhealthy frustration for a few minutes.

Quite lightly tested :)