### PR TITLE
Allow custom emoji and also delete bot duplicate messages after a little while

### DIFF
--- a/extensions/duplicate_message_policing.py
+++ b/extensions/duplicate_message_policing.py
@@ -50,7 +50,7 @@ async def delete_duplicate(event: hikari.GuildMessageCreateEvent) -> None:
         or "http" in event.content  # allow links
         or re.match("<@\\d+>", event.content)
         or re.fullmatch(
-            "<:[a-z]+:\\d+>", event.content
+            "<a?:[a-z]+:\\d+>", event.content
         )  # allow custom Discord 'emoji' in the format <:catswag:989147563854823444>
     ):
         # force the bot to not interact with this message at all e.g. in case of bug or in some other cases

--- a/extensions/duplicate_message_policing.py
+++ b/extensions/duplicate_message_policing.py
@@ -13,7 +13,7 @@ import sqlite3
 import re
 import humanize
 from datetime import datetime, timezone
-
+import asyncio
 
 plugin = lightbulb.Plugin("duplicate_message_policing")
 
@@ -46,10 +46,12 @@ async def delete_duplicate(event: hikari.GuildMessageCreateEvent) -> None:
         or event.is_webhook
         or event.is_bot
         or event.content.startswith(nodelete_flag)
-        or "http" in event.content  # allow links
-        or "@" in event.content  # allow mentions
         or len(event.content) <= 2  # allow short messages
-        or re.fullmatch("<:[a-z]+:\\d+>", event.content) # allow custom Discord 'emoji' in the format <:catswag:989147563854823444>
+        or "http" in event.content  # allow links
+        or re.match("<@\\d+>", event.content)
+        or re.fullmatch(
+            "<:[a-z]+:\\d+>", event.content
+        )  # allow custom Discord 'emoji' in the format <:catswag:989147563854823444>
     ):
         # force the bot to not interact with this message at all e.g. in case of bug or in some other cases
         return
@@ -72,13 +74,16 @@ async def delete_duplicate(event: hikari.GuildMessageCreateEvent) -> None:
 
         original_time_sent = datetime.fromisoformat(previous[2])
 
-        await event.message.respond(
+        response = await event.message.respond(
             f"Hey {event.author.mention}! Unfortunately,"
             f" your message: `{event.message.content}`"
             f" (first sent {humanize.naturaltime(datetime.now(timezone.utc) - original_time_sent)} by {event.get_guild().get_member(previous[0]).display_name})"
             f" was deleted as it is ***NOT*** unique. Add some creativity to your message :robot:",
             user_mentions=True,
         )
+        # delete deletion message after sixty seconds (second best, due to inability to send ephemeral message directly)
+        await asyncio.sleep(60)
+        await response.delete()
 
 
 @plugin.listener(hikari.GuildMessageDeleteEvent)

--- a/extensions/duplicate_message_policing.py
+++ b/extensions/duplicate_message_policing.py
@@ -49,6 +49,7 @@ async def delete_duplicate(event: hikari.GuildMessageCreateEvent) -> None:
         or "http" in event.content  # allow links
         or "@" in event.content  # allow mentions
         or len(event.content) <= 2  # allow short messages
+        or re.fullmatch("<:[a-z]+:\\d+>", event.content) # allow custom Discord 'emoji' in the format <:catswag:989147563854823444>
     ):
         # force the bot to not interact with this message at all e.g. in case of bug or in some other cases
         return


### PR DESCRIPTION
The messages staying around get annoying, but we can't switch them to ephemeral (only visible to sending user) as far as I can tell (despite the Discord blog post implying that you can indeed do that).

As per usual, extensively tested. 