### PR TITLE
add basic meme stats

### DIFF
--- a/db.py
+++ b/db.py
@@ -15,10 +15,12 @@ def start():
     c.execute("CREATE TABLE IF NOT EXISTS message_counts (user TEXT, count INTEGER)")
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS message_counts_idx ON message_counts (user)")
     c.execute("CREATE TABLE IF NOT EXISTS message_hashes (user TEXT, message_id TEXT, message_hash TEXT, time_sent TEXT)")
-    c.execute("CREATE TABLE IF NOT EXISTS image_hashes (hash TEXT, message_id TEXT, channel_id TEXT, guild_id TEXT)")
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS message_hashes_idx ON message_hashes (message_hash)")
+    c.execute("CREATE TABLE IF NOT EXISTS image_hashes (hash TEXT, message_id TEXT, channel_id TEXT, guild_id TEXT)")
     c.execute("CREATE TABLE IF NOT EXISTS message_deletes (user TEXT, count INTEGER)")
     c.execute("CREATE UNIQUE INDEX IF NOT EXISTS message_deletes_idx ON message_deletes (user)")
+    c.execute("CREATE TABLE IF NOT EXISTS meme_stats (user TEXT, message_id TEXT, meme_score INTEGER, time_sent TEXT)")
+
     try:
         c.execute("ALTER TABLE image_hashes ADD hash_color TEXT NOT NULL")
     except Exception as ex:

--- a/extensions/meme_rater.py
+++ b/extensions/meme_rater.py
@@ -75,17 +75,15 @@ async def main(event: hikari.GuildMessageCreateEvent) -> None:
         )
     else:
         await event.message.add_reaction(emoji="💩")
+
     # add some basic meme stats to the db so we can track who is improving, rotting, or standing still
-    try:
-        # avg rating row inserted is just for this set of memes. Another query elsewhere aggregates.
-        cursor.execute(
-            "insert into meme_stats values(?, ?, ?, ?)",
-            (event.author_id, event.message_id, avg_rating, event.message.timestamp),
-        )
-        db.commit()
-    except sqlite3.IntegrityError:
-        logging.error(f"couldn't write meme stat to db :(: {event.author.id} {event.message_id}")
-        pass
+    # avg rating row inserted is just for this set of memes. Another query elsewhere aggregates.
+    cursor.execute(
+        "insert into meme_stats values(?, ?, ?, ?)",
+        (event.author_id, event.message_id, avg_rating, event.message.timestamp),
+    )
+    db.commit()
+
 
 
 def load(bot: lightbulb.BotApp) -> None:

--- a/extensions/meme_stats.py
+++ b/extensions/meme_stats.py
@@ -1,6 +1,6 @@
 """
 Displays a graph of meme ratings for a user, grouped by day.
-Todo: make day/hour/week whatever a parameter.
+Todo: make day/hour/week/month/year/decade/century/millennium whatever a parameter.
 """
 import db
 import hikari
@@ -9,12 +9,15 @@ import matplotlib.font_manager as fm
 import matplotlib.image as image
 import matplotlib.pyplot as plt
 from io import BytesIO
+import pandas as pd # sorry
 
 plugin = lightbulb.Plugin("MemeStats")
 
 @plugin.command
 @lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
 @lightbulb.option("target", "The member to roast (or not?).", hikari.User, required=True)
+# todo: expand this
+@lightbulb.option("period", "time period.",  choices=["month", "year"], default="month", required=False)
 @lightbulb.command("memestats", "See someone's average meme rating over time")
 @lightbulb.implements(lightbulb.PrefixCommand,lightbulb.SlashCommand)
 async def main(ctx: lightbulb.Context) -> None:
@@ -22,33 +25,39 @@ async def main(ctx: lightbulb.Context) -> None:
     cursor = db.cursor()
     user_id = ctx.options.target.id
     user = guild.get_member(user_id)
+    time_period = ctx.options.period
 
     # todo: add a limit or aggregation of greater time periods or whatever
     # todo: get someone else to do this
-    data = cursor.execute("""
-        select strftime('%Y-%m-%d', time_sent) as day,
+    data = cursor.execute(f"""
+        select strftime('%Y-%m-%d', time_sent) as time_period,
             AVG(meme_score) as avg_meme_score
         from meme_stats
-        where user = ?
-        group BY user, day
+        where user = ? and time_sent >= date('now', '-1 {time_period}')
+        group BY user, time_period
     """, (user_id,)).fetchall()
 
     if not data:
         return await ctx.respond(f"Looks like {user.display_name} hasn't had any of their memes rated yet. 10/10 for them!")
-    
+    # Convert SQLite query result into a DataFrame.
+    # random commands found by a combination of chatgpt and google that seem to work
+    df = pd.DataFrame(data, columns=["time_period", "avg_meme_score"])
+    df["time_period"] = pd.to_datetime(df["time_period"])
+    df.set_index("time_period", inplace=True)
+    # Create a complete date range and reindex.
+    df = df.asfreq("d", fill_value=None)
+
     # graphic plot thingy
     buffer = BytesIO()
-    x = [item[0] for item in data]
-    y = [item[1] for item in data]
     plt.style.use('ggplot')
     plt.figure(figsize=(10, 6))
-    plt.plot(x, y, marker='o', color='#1f77b4', linewidth=2, markersize=8)
-    plt.xlabel('Day', fontsize=14)
+    plt.plot(df.index, df["avg_meme_score"], marker='o', color='#1f77b4', linewidth=2, markersize=8)
+    plt.xlabel('Days', fontsize=14)
     plt.ylabel('Average Meme Score', fontsize=14)
-    plt.title(f'Meme Scores Over Time (Days) for {user.display_name}', fontsize=16)
-    plt.xticks(fontsize=12)
+    plt.title(f'Meme Scores Over Time ({time_period}) for {user.display_name}', fontsize=16)
+    plt.xticks(fontsize=8)
     plt.yticks(fontsize=12)
-    plt.grid(True)
+    plt.grid(False)
     plt.tight_layout()
     plt.savefig(buffer, format='png', dpi=300)
     plt.close()

--- a/extensions/meme_stats.py
+++ b/extensions/meme_stats.py
@@ -1,0 +1,59 @@
+"""
+Displays a graph of meme ratings for a user, grouped by day.
+Todo: make day/hour/week whatever a parameter.
+"""
+import db
+import hikari
+import lightbulb
+import matplotlib.font_manager as fm
+import matplotlib.image as image
+import matplotlib.pyplot as plt
+from io import BytesIO
+
+plugin = lightbulb.Plugin("MemeStats")
+
+@plugin.command
+@lightbulb.add_cooldown(10, 1, lightbulb.UserBucket)
+@lightbulb.option("target", "The member to roast (or not?).", hikari.User, required=True)
+@lightbulb.command("memestats", "See someone's average meme rating over time")
+@lightbulb.implements(lightbulb.PrefixCommand,lightbulb.SlashCommand)
+async def main(ctx: lightbulb.Context) -> None:
+    guild = ctx.get_guild()
+    cursor = db.cursor()
+    user_id = ctx.options.target.id
+    user = guild.get_member(user_id)
+
+    # todo: add a limit or aggregation of greater time periods or whatever
+    # todo: get someone else to do this
+    data = cursor.execute("""
+        select strftime('%Y-%m-%d', time_sent) as day,
+            AVG(meme_score) as avg_meme_score
+        from meme_stats
+        where user = ?
+        group BY user, day
+    """, (user_id,)).fetchall()
+
+    if not data:
+        return await ctx.respond(f"Looks like {user.display_name} hasn't had any of their memes rated yet. 10/10 for them!")
+    
+    # graphic plot thingy
+    buffer = BytesIO()
+    x = [item[0] for item in data]
+    y = [item[1] for item in data]
+    plt.style.use('ggplot')
+    plt.figure(figsize=(10, 6))
+    plt.plot(x, y, marker='o', color='#1f77b4', linewidth=2, markersize=8)
+    plt.xlabel('Day', fontsize=14)
+    plt.ylabel('Average Meme Score', fontsize=14)
+    plt.title(f'Meme Scores Over Time (Days) for {user.display_name}', fontsize=16)
+    plt.xticks(fontsize=12)
+    plt.yticks(fontsize=12)
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(buffer, format='png', dpi=300)
+    plt.close()
+    return await ctx.respond(hikari.Bytes(buffer.getvalue(), 'meme_score_results.png'))
+    
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,3 +67,4 @@ urllib3==2.3.0
 uvloop==0.21.0; sys_platform != "win32"
 wordcloud==1.9.4
 yarl==1.18.3
+pandas==2.2.3


### PR DESCRIPTION
Provides a basic graph of meme ratings for a user over time.

Tested to verify that a graph gets generated and some things get selected/inserted.

Aggregates by day, will become unwieldy fairly quickly.