### PR TITLE
Send meme deletion notifcations to a dedicated channel

### DIFF
--- a/behaviours/__init__.py
+++ b/behaviours/__init__.py
@@ -47,7 +47,7 @@ _message_delete_chain: _Chain[hikari.GuildMessageDeleteEvent] = [
 _reaction_add_chain: _Chain[hikari.GuildReactionAddEvent] = [
     [
         meme_rater.respond_to_question_mark,
-        meme_rater.delete_meme,
+        meme_rater.meme_reaction,
     ],
     [
         userinfo.analyse_reaction,

--- a/behaviours/meme_rater.py
+++ b/behaviours/meme_rater.py
@@ -243,19 +243,21 @@ async def respond_to_question_mark(event: hikari.GuildReactionAddEvent) -> None:
 
         raise behaviours.EndProcessing()
 
+
 def get_explanation(message_id: hikari.Snowflake):
     cursor = db.cursor()
     cursor.execute(
-            """
+        """
         SELECT meme_reasoning
         FROM meme_stats
         WHERE message_id = ?""",
-            (str(message_id),),
-        )
+        (str(message_id),),
+    )
     row = cursor.fetchone()
     if row is None:
         return None
     return row[0]
+
 
 def is_message_rated_shit(message_id: hikari.Snowflake) -> bool:
     cursor = db.cursor()
@@ -348,7 +350,9 @@ async def delete_meme(
                 .add_field("Sent by", message.author.mention)
                 .add_field("Deemed shit by", dislikers)
                 .add_field("Liked by", likers)
-                .add_field("Our justification", get_explanation(message.id) or 'It was shit')
+                .add_field(
+                    "Our justification", get_explanation(message.id) or "It was shit"
+                )
                 # .set_image() This is hard, leave for someone else to do
                 .set_footer("Try again with a better meme")
             ),


### PR DESCRIPTION
Example:

![Screenshot_20250514_001630](https://github.com/user-attachments/assets/d23c00ba-4af6-4847-bbd9-f31b7be866ff)


This doesn't include the actual meme itself because:

1. That's hard
2. I'm not fully convinced it should be present at all. Why go through all the trouble of deleting it just to send it again?